### PR TITLE
Add identity resource group parameter to `spin azure assign-role cosmosdb`

### DIFF
--- a/internal/pkg/aks/service.go
+++ b/internal/pkg/aks/service.go
@@ -76,6 +76,8 @@ func (s *Service) GetCluster(ctx context.Context, resourceGroup, clusterName str
 		"--subscription", s.subscriptionID,
 	)
 
+	fmt.Println("Executing command:", strings.Join(cmd.Args, " "))
+
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to get AKS cluster: %w\nOutput: %s", err, string(output))
@@ -125,6 +127,8 @@ func (s *Service) CheckWorkloadIdentity(ctx context.Context) (bool, error) {
 		"--output", "tsv",
 	)
 
+	fmt.Println("Executing command:", strings.Join(cmd.Args, " "))
+
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return false, fmt.Errorf("failed to check workload identity: %w\nOutput: %s", err, string(output))
@@ -153,6 +157,8 @@ func (s *Service) EnableWorkloadIdentity(ctx context.Context) error {
 		"--enable-oidc-issuer",
 		"--enable-workload-identity",
 	)
+
+	fmt.Println("Executing command:", strings.Join(cmd.Args, " "))
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -186,6 +192,8 @@ func (s *Service) DeploySpinOperator(ctx context.Context) error {
 		"--subscription", s.subscriptionID,
 		"--overwrite-existing",
 	)
+
+	fmt.Println("Executing command:", strings.Join(getCredsCmd.Args, " "))
 
 	output, err := getCredsCmd.CombinedOutput()
 	if err != nil {
@@ -357,6 +365,8 @@ func (s *Service) CreateServiceAccount(ctx context.Context, identityName string)
 		"--overwrite-existing",
 	)
 
+	fmt.Println("Executing command:", strings.Join(getCredsCmd.Args, " "))
+
 	output, err := getCredsCmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to get Kubernetes credentials: %w\nOutput: %s", err, string(output))
@@ -431,6 +441,8 @@ func (s *Service) getIdentityClientID(name, resourceGroup string) (string, error
 		"--output", "tsv",
 	)
 
+	fmt.Println("Executing command:", strings.Join(cmd.Args, " "))
+
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("failed to get identity client ID: %w\nOutput: %s", err, string(output))
@@ -448,6 +460,8 @@ func (s *Service) CreateIdentity(ctx context.Context, identityName string, resou
 		"--resource-group", resourceGroup,
 		"--subscription", s.subscriptionID,
 	)
+
+	fmt.Println("Executing command:", strings.Join(cmd.Args, " "))
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -505,6 +519,8 @@ func (s *Service) createFederatedCredential(identityName, clientID, clusterName,
 		"--audiences", "api://AzureADTokenExchange",
 	)
 
+	fmt.Println("Executing command:", strings.Join(cmd.Args, " "))
+
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to create federated identity credential: %w\nOutput: %s", err, string(output))
@@ -523,6 +539,8 @@ func (s *Service) getClusterOIDCIssuerURL(clusterName, resourceGroup string) (st
 		"--query", "oidcIssuerProfile.issuerUrl",
 		"--output", "tsv",
 	)
+
+	fmt.Println("Executing command:", strings.Join(cmd.Args, " "))
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/pkg/bind/cosmosdb.go
+++ b/internal/pkg/bind/cosmosdb.go
@@ -21,12 +21,12 @@ func NewCosmosDBService(credential azcore.TokenCredential, subscriptionID string
 	}
 }
 
-func (s *CosmosDBService) BindCosmosDB(ctx context.Context, name, resourceGroup, identityName string) error {
+func (s *CosmosDBService) BindCosmosDB(ctx context.Context, name, resourceGroup, identityName, identityResourceGroup string) error {
 	if err := s.validateCosmosDBAccount(name, resourceGroup); err != nil {
 		return err
 	}
 
-	identityPrincipalID, err := s.getIdentityPrincipalID(identityName, resourceGroup)
+	identityPrincipalID, err := s.getIdentityPrincipalID(identityName, identityResourceGroup)
 	if err != nil {
 		return err
 	}
@@ -52,6 +52,8 @@ func (s *CosmosDBService) validateCosmosDBAccount(name, resourceGroup string) er
 		"--subscription", s.subscriptionID,
 	)
 
+	fmt.Println("Executing command:", strings.Join(cmd.Args, " "))
+
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("failed to check if CosmosDB exists: %w\nOutput: %s", err, string(output))
@@ -63,6 +65,8 @@ func (s *CosmosDBService) validateCosmosDBAccount(name, resourceGroup string) er
 		"--resource-group", resourceGroup,
 		"--subscription", s.subscriptionID,
 	)
+
+	fmt.Println("Executing command:", strings.Join(cmd.Args, " "))
 
 	output, err = cmd.CombinedOutput()
 	if err != nil {
@@ -82,6 +86,8 @@ func (s *CosmosDBService) getIdentityPrincipalID(name, resourceGroup string) (st
 		"--query", "principalId",
 		"--output", "tsv",
 	)
+
+	fmt.Println("Executing command:", strings.Join(cmd.Args, " "))
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -108,6 +114,8 @@ func (s *CosmosDBService) assignRoleToCosmosDB(identityPrincipalID, cosmosDBName
 		"--scope", cosmosDBResourceID,
 		"--subscription", s.subscriptionID,
 	)
+
+	fmt.Println("Executing command:", strings.Join(cmd.Args, " "))
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -145,6 +153,8 @@ func (s *CosmosDBService) getDBAndContainerInfo(name, resourceGroup string) (str
 		"--output", "tsv",
 	)
 
+	fmt.Println("Executing command:", strings.Join(dbCmd.Args, " "))
+
 	dbOutput, err := dbCmd.CombinedOutput()
 	if err != nil {
 		return "", "", fmt.Errorf("failed to get database info: %w", err)
@@ -164,6 +174,8 @@ func (s *CosmosDBService) getDBAndContainerInfo(name, resourceGroup string) (str
 		"--query", "[0].name",
 		"--output", "tsv",
 	)
+
+	fmt.Println("Executing command:", strings.Join(containerCmd.Args, " "))
 
 	containerOutput, err := containerCmd.CombinedOutput()
 	if err != nil {

--- a/internal/pkg/cmd/assign_role.go
+++ b/internal/pkg/cmd/assign_role.go
@@ -40,7 +40,7 @@ func newBindCosmosDBCommand() *cobra.Command {
 			}
 
 			if cfg.SubscriptionID == "" {
-				return fmt.Errorf("subscription ID not set, please set it using Azure CLI or environment variables")
+				return fmt.Errorf("subscription ID not set, please set it using `spin azure login`")
 			}
 
 			if resourceGroup == "" {
@@ -73,7 +73,7 @@ func newBindCosmosDBCommand() *cobra.Command {
 	cmd.Flags().StringVar(&name, "name", "", "Name of the CosmosDB account (required)")
 	cmd.Flags().StringVar(&resourceGroup, "resource-group", "", "Resource group of the CosmosDB account")
 	cmd.Flags().StringVar(&identityName, "identity", "", "Name of the identity to assign roles to")
-	cmd.MarkFlagsRequiredTogether("name")
+	cmd.MarkFlagRequired("name")
 
 	return cmd
 }

--- a/internal/pkg/cmd/assign_role.go
+++ b/internal/pkg/cmd/assign_role.go
@@ -83,7 +83,9 @@ func newBindCosmosDBCommand() *cobra.Command {
 	cmd.Flags().StringVar(&resourceGroup, "resource-group", "", "Resource group of the CosmosDB account")
 	cmd.Flags().StringVar(&identityName, "identity", "", "Name of the identity to assign roles to")
 	cmd.Flags().StringVar(&identityResourceGroup, "identity-resource-group", "", "Resource group of the managed identity (defaults to the CosmosDB resource group if not specified)")
-	cmd.MarkFlagRequired("name")
+	if err := cmd.MarkFlagRequired("name"); err != nil {
+		panic(fmt.Sprintf("failed to mark flag 'from' as required: %v", err))
+	}
 
 	return cmd
 }

--- a/internal/pkg/cmd/cluster.go
+++ b/internal/pkg/cmd/cluster.go
@@ -102,7 +102,7 @@ func newClusterCreateCommand() *cobra.Command {
 			}
 
 			if cfg.SubscriptionID == "" {
-				return fmt.Errorf("subscription ID not set, please set it using Azure CLI or environment variables")
+				return fmt.Errorf("subscription ID not set, please set it using `spin azure login`")
 			}
 
 			aksService, err := aks.NewService(credential, cfg.SubscriptionID)
@@ -191,7 +191,7 @@ func newClusterUseCommand() *cobra.Command {
 			}
 
 			if cfg.SubscriptionID == "" {
-				return fmt.Errorf("subscription ID not set, please set it using Azure CLI or environment variables")
+				return fmt.Errorf("subscription ID not set, please set it using `spin azure login`")
 			}
 
 			if resourceGroup == "" {
@@ -229,7 +229,7 @@ func newClusterUseCommand() *cobra.Command {
 	cmd.Flags().StringVar(&name, "name", "", "Name of the existing AKS cluster (required)")
 	cmd.Flags().StringVar(&resourceGroup, "resource-group", "", "Resource group of the existing AKS cluster")
 	cmd.Flags().BoolVar(&installSpinOperator, "install-spin-operator", false, "Install Spin Operator on the cluster after selection")
-	cmd.MarkFlagsRequiredTogether("name")
+	cmd.MarkFlagRequired("name")
 	return cmd
 }
 
@@ -250,7 +250,7 @@ func newClusterCheckIdentityCommand() *cobra.Command {
 			}
 
 			if cfg.SubscriptionID == "" {
-				return fmt.Errorf("subscription ID not set, please set it using Azure CLI or environment variables")
+				return fmt.Errorf("subscription ID not set, please set it using `spin azure login`")
 			}
 
 			aksService, err := aks.NewService(credential, cfg.SubscriptionID)
@@ -300,7 +300,7 @@ func newClusterInstallSpinOperatorCommand() *cobra.Command {
 			}
 
 			if cfg.SubscriptionID == "" {
-				return fmt.Errorf("subscription ID not set, please set it using Azure CLI or environment variables")
+				return fmt.Errorf("subscription ID not set, please set it using `spin azure login`")
 			}
 
 			aksService, err := aks.NewService(credential, cfg.SubscriptionID)

--- a/internal/pkg/cmd/cluster.go
+++ b/internal/pkg/cmd/cluster.go
@@ -229,7 +229,9 @@ func newClusterUseCommand() *cobra.Command {
 	cmd.Flags().StringVar(&name, "name", "", "Name of the existing AKS cluster (required)")
 	cmd.Flags().StringVar(&resourceGroup, "resource-group", "", "Resource group of the existing AKS cluster")
 	cmd.Flags().BoolVar(&installSpinOperator, "install-spin-operator", false, "Install Spin Operator on the cluster after selection")
-	cmd.MarkFlagRequired("name")
+	if err := cmd.MarkFlagRequired("name"); err != nil {
+		panic(fmt.Sprintf("failed to mark flag 'name' as required: %v", err))
+	}
 	return cmd
 }
 

--- a/internal/pkg/cmd/deploy.go
+++ b/internal/pkg/cmd/deploy.go
@@ -29,7 +29,7 @@ func NewDeployCommand() *cobra.Command {
 			}
 
 			if cfg.SubscriptionID == "" {
-				return fmt.Errorf("subscription ID not set, please set it using Azure CLI or environment variables")
+				return fmt.Errorf("subscription ID not set, please set it using `spin azure login`")
 			}
 
 			if from == "" {

--- a/internal/pkg/cmd/identity.go
+++ b/internal/pkg/cmd/identity.go
@@ -58,7 +58,7 @@ func newIdentityCreateCommand() *cobra.Command {
 			}
 
 			if cfg.SubscriptionID == "" {
-				return fmt.Errorf("subscription ID not set, please set it using Azure CLI or environment variables")
+				return fmt.Errorf("subscription ID not set, please set it using `spin azure login`")
 			}
 
 			aksService, err := aks.NewService(credential, cfg.SubscriptionID)
@@ -85,6 +85,6 @@ func newIdentityCreateCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&name, "name", "workload-identity", "Name of the identity to create")
 	cmd.Flags().StringVar(&resourceGroup, "resource-group", "", "Resource group for the identity (defaults to the resource group of the current cluster)")
-	cmd.MarkFlagsRequiredTogether("name")
+	cmd.MarkFlagRequired("name")
 	return cmd
 }

--- a/internal/pkg/cmd/identity.go
+++ b/internal/pkg/cmd/identity.go
@@ -85,6 +85,8 @@ func newIdentityCreateCommand() *cobra.Command {
 
 	cmd.Flags().StringVar(&name, "name", "workload-identity", "Name of the identity to create")
 	cmd.Flags().StringVar(&resourceGroup, "resource-group", "", "Resource group for the identity (defaults to the resource group of the current cluster)")
-	cmd.MarkFlagRequired("name")
+	if err := cmd.MarkFlagRequired("name"); err != nil {
+		panic(fmt.Sprintf("failed to mark flag 'name' as required: %v", err))
+	}
 	return cmd
 }


### PR DESCRIPTION
- **Update error messages to reference 'spin azure login'**
- **adding identity resource group parameter and more logging**
