### PR TITLE
identity: add skip-service-account flag to create identity without service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ spin azure identity create # will create a new identity called "workload-identit
 spin azure identity create --name my-custom-identity # will create a new identity called "my-custom-identity"
 ```
 
+This command creates an Azure managed identity, sets up a Kubernetes service account and federated credential for it. If you don't have a cluster selected, you can use the `--skip-service-account` flag:
+
+```bash
+spin azure identity create --name my-identity --resource-group my-rg --skip-service-account
+```
+
+This will create just the Azure managed identity without Kubernetes service account or federated credentials. Later, when you have a cluster, you can add those using the `identity use` command described in [Use an existing identity](#use-an-existing-identity) section.
+
 ### Use an existing identity
 
 ```bash


### PR DESCRIPTION
This changes a few things:
1. now the `identity create` will fail out if there is no cluster selected
2. if the `skip-service-account` flag is set, it will not create the service account and federated credential in the `identity create` command

Signed-off-by: Jiaxiao (mossaka) Zhou <duibao55328@gmail.com>
